### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ node_js:
   - "node"
   - "10"
   - "8"
-  - "6"
 script: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - "node"
-  - "lts/*"
+  - "10"
+  - "8"
+  - "6"
 script: npm test


### PR DESCRIPTION
Currently Node.js 6, 8 and 10 are LTS as there is always more than one active LTS branch.

Travis CI used the last LTS branch when `lts/*` is used which does not include Node.js 8 (which is still used on many platforms) or Node.js 6.