### PR TITLE
ci: cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ node_js:
   - "node"
   - "lts/*"
 script: npm test
+cache:
+  directories:
+    - "node_modules"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,4 @@ node_js:
   - "node"
   - "lts/*"
 script: npm test
-cache:
-  directories:
-    - "node_modules"
+cache: npm


### PR DESCRIPTION
Caching `node_modules` between builds can speed up the CI builds significantly.