### PR TITLE
ci: use npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - "node"
   - "lts/*"
 script: npm test
+install: npm install


### PR DESCRIPTION
By default Travis CI used `npm ci` if it finds a lockfile starting with newer Node.js versions. But this does not reflect what is happening on the consumer side (npmjs and npm / yarn users) as the lockfiles are not used there and have no effect.