### PR TITLE
chore: only Node.js 8 and newer is supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "lib/phin.min.js",
     "LICENSE"
   ],
+  "engines": {
+    "node": ">= 8"
+  },
   "dependencies": {
     "centra": "^2.1.0"
   }


### PR DESCRIPTION
This project does not support Node.js 6.

See https://github.com/ethanent/phin/pull/24