### PR TITLE
phin: corrects a ddos vector using hasOwnProperty

### DIFF
--- a/lib/phin.js
+++ b/lib/phin.js
@@ -35,7 +35,7 @@ const centra = require('centra')
 */
 const phin = async (opts) => {
 	if (typeof(opts) !== 'string') {
-		if (!opts.hasOwnProperty('url')) {
+		if (!has(opts, 'url')) {
 			throw new Error('Missing url option from options for request method.')
 		}
 	}
@@ -57,7 +57,7 @@ const phin = async (opts) => {
 
 	const res = await req.send()
 
-	if (res.headers.hasOwnProperty('location') && opts.followRedirects) {
+	if (has(res.headers, 'location') && opts.followRedirects) {
 		opts.url = (new URL(res.headers['location'], opts.url)).toString()
 
 		return await phin(opts)
@@ -98,12 +98,16 @@ phin.defaults = (defaultOpts) => async (opts) => {
 	const nops = typeof opts === 'string' ? {'url': opts} : opts
 
 	Object.keys(defaultOpts).forEach((doK) => {
-		if (!nops.hasOwnProperty(doK) || nops[doK] === null) {
+		if (!has(nops, doK) || nops[doK] === null) {
 			nops[doK] = defaultOpts[doK]
 		}
 	})
 
-	return await phin(nops)
+	return phin(nops)
+}
+
+function has(opts, key) {
+  return Object.prototype.hasOwnProperty.call(opts, key)
 }
 
 module.exports = phin

--- a/tests/test.js
+++ b/tests/test.js
@@ -183,11 +183,11 @@ w.add('Simple GET request', (result) => {
 })
 
 w.add('POST request with body', (result) => {
-	p({
-		'url': 'http://localhost:5136/testpost',
-		'method': 'POST',
-		'data': 'Hey there!'
-	}, (err, res) => {
+	const opts = Object.create(null)
+	opts.url = 'http://localhost:5136/testpost'
+	opts.method = 'POST'
+	opts.data = 'Hey there!'
+	p(opts, (err, res) => {
 		if (err) {
 			result(false, err)
 			return


### PR DESCRIPTION
phin will unexpectedly throw if an options object is passed that doesn't
not inherit from Object ( `Object.create(null)` )

This replaces all occurances of {}.hasOwnProperty with a wrapper function
that calls the function from Object.prototype

Semver: patch