### PR TITLE
adds URL as valid type for options.url

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -3,7 +3,7 @@
 import * as http from 'http'
 
 interface IOptionsBase {
-  url: string
+  url: string | URL
   method?: string
   headers?: object
   core?: http.ClientRequestArgs


### PR DESCRIPTION
since both phin and centra works with `options.url` being of type `URL` instead of `string`