### PR TITLE
Simplify type definitions for overloaded function

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -17,21 +17,11 @@ interface IOptionsBase {
   path?: string
 }
 
-declare function phin<T>(options:
-  phin.IJSONResponseOptions |
-  phin.IWithData<phin.IJSONResponseOptions> |
-  phin.IWithForm<phin.IJSONResponseOptions>): Promise<phin.IJSONResponse<T>>
+type Options<T extends IOptionsBase> = T | phin.IWithData<T> | phin.IWithForm<T>
 
-declare function phin(options:
-  phin.IStreamResponseOptions |
-  phin.IWithData<phin.IStreamResponseOptions> |
-  phin.IWithForm<phin.IStreamResponseOptions>): Promise<phin.IStreamResponse>
-
-declare function phin(options:
-  phin.IOptions |
-  phin.IWithData<phin.IOptions> |
-  phin.IWithForm<phin.IOptions> |
-  string): Promise<phin.IResponse>
+declare function phin<T>(options: Options<phin.IJSONResponseOptions>): Promise<phin.IJSONResponse<T>>
+declare function phin(options: Options<phin.IStreamResponseOptions>): Promise<phin.IStreamResponse>
+declare function phin(options: Options<phin.IOptions> | string): Promise<phin.IResponse>
 
 declare namespace phin {
   // Form and data property has been written this way so they're mutually exclusive.


### PR DESCRIPTION
This just makes the type definitions simpler for the overloaded `phin()` function