### PR TITLE
Add production dependency audit before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "types.d.ts",
   "scripts": {
     "test": "node ./tests/test.js",
-    "prepublishOnly": "npm test",
+    "auditdeps": "npm audit --production",
+    "prepublishOnly": "npm test && npm run auditdeps",
     "gendocs": "rm -r docs || true && jsdoc -R README.md -d ./docs lib/phin.js"
   },
   "repository": {


### PR DESCRIPTION
Adds an `auditdeps` npm script to audit production dependencies for vulnerabilities (using the built-in `npm audit --production`) and runs the script before publishing