### PR TITLE
fix: missing phin prefix in types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -24,8 +24,8 @@ declare function phin<T>(options:
 
 declare function phin(options:
   phin.IStringResponseOptions |
-  IWithData<phin.IStringResponseOptions> |
-  IWithForm<phin.IStringResponseOptions>): Promise<phin.IStringResponse>
+  phin.IWithData<phin.IStringResponseOptions> |
+  phin.IWithForm<phin.IStringResponseOptions>): Promise<phin.IStringResponse>
 
 declare function phin(options:
   phin.IStreamResponseOptions |


### PR DESCRIPTION
Using those otherwise fails with:

```
node_modules/phin/types.d.ts:27:3 - error TS2304: Cannot find name 'IWithData'.

27   IWithData<phin.IStringResponseOptions> |
     ~~~~~~~~~

node_modules/phin/types.d.ts:28:3 - error TS2304: Cannot find name 'IWithForm'.

28   IWithForm<phin.IStringResponseOptions>): Promise<phin.IStringResponse>
     ~~~~~~~~~
```